### PR TITLE
[userGroup] verify invitation + request

### DIFF
--- a/src/components/pages/continue/processing.tsx
+++ b/src/components/pages/continue/processing.tsx
@@ -1,0 +1,33 @@
+import { Alert, AlertIcon } from "@chakra-ui/core";
+import { useLocalRouter } from "@components/@core/local-link";
+import useTranslation from "@configs/i18n/useTranslation";
+import React, { useEffect } from "react";
+
+interface ProcessingProps {
+  loading: boolean;
+  success: boolean;
+  redirect?: boolean;
+}
+
+export default function Processing({ success, loading, redirect = true }: ProcessingProps) {
+  const { t } = useTranslation();
+  const router = useLocalRouter();
+
+  useEffect(() => {
+    if (success && redirect) {
+      router.push("/", true);
+    }
+  }, [success]);
+
+  return loading ? (
+    <Alert m={6} borderRadius="md">
+      <AlertIcon />
+      {t("PROCESSING")}
+    </Alert>
+  ) : (
+    <Alert m={6} borderRadius="md" status={success ? "success" : "error"}>
+      <AlertIcon />
+      {t(success ? "SUCCESS" : "INVALID_REQUEST")}
+    </Alert>
+  );
+}

--- a/src/components/pages/continue/verify-invitation/index.tsx
+++ b/src/components/pages/continue/verify-invitation/index.tsx
@@ -1,0 +1,14 @@
+import { axVerifyInvitation } from "@services/usergroup.service";
+import React, { useEffect, useState } from "react";
+
+import Processing from "../processing";
+
+export default function VerifyInvitationComponent({ token }) {
+  const [status, setStatus] = useState({ loading: true, success: false });
+
+  useEffect(() => {
+    axVerifyInvitation(token).then((res) => setStatus({ loading: false, ...res }));
+  }, []);
+
+  return <Processing {...status} />;
+}

--- a/src/components/pages/continue/verify-request/index.tsx
+++ b/src/components/pages/continue/verify-request/index.tsx
@@ -1,0 +1,14 @@
+import { axVerifyRequest } from "@services/usergroup.service";
+import React, { useEffect, useState } from "react";
+
+import Processing from "../processing";
+
+export default function VerifyRequestComponent({ token }) {
+  const [status, setStatus] = useState({ loading: true, success: false });
+
+  useEffect(() => {
+    axVerifyRequest(token).then((res) => setStatus({ loading: false, ...res }));
+  }, []);
+
+  return <Processing {...status} />;
+}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -258,6 +258,7 @@
       "USERGROUPS": "Groups"
     }
   },
+  "INVALID_REQUEST": "Invalid Request",
   "LEADERBOARD": {
     "TIP": "Leaderboard is based on all activities done by a user. Activity will update once every hour.",
     "TITLE": "Leaderboard"
@@ -466,6 +467,7 @@
     "TITLE": "Account verification"
   },
   "PREV": "Previous",
+  "PROCESSING": "Processing...",
   "SAVE": "Save",
   "SIGN_IN": {
     "FORGOT_PASSWORD_LINK": "Forgot password?",
@@ -499,5 +501,6 @@
     },
     "TITLE": "Sign up"
   },
+  "SUCCESS": "Success",
   "TOGGLE": "toggle"
 }

--- a/src/pages/continue/verify-invitation.tsx
+++ b/src/pages/continue/verify-invitation.tsx
@@ -1,0 +1,18 @@
+import { authorizedPageSSR } from "@components/auth/auth-redirect";
+import VerifyInvitationComponent from "@components/pages/continue/verify-invitation";
+import { Role } from "@interfaces/custom";
+import React from "react";
+
+const VerifyInvitation = ({ token }) => <VerifyInvitationComponent token={token} />;
+
+VerifyInvitation.getInitialProps = async (ctx) => {
+  authorizedPageSSR([Role.Any], ctx, true);
+  return { token: ctx.query.token };
+};
+
+VerifyInvitation.config = {
+  header: false,
+  footer: false
+};
+
+export default VerifyInvitation;

--- a/src/pages/continue/verify-request.tsx
+++ b/src/pages/continue/verify-request.tsx
@@ -1,0 +1,18 @@
+import { authorizedPageSSR } from "@components/auth/auth-redirect";
+import VerifyRequestComponent from "@components/pages/continue/verify-request";
+import { Role } from "@interfaces/custom";
+import React from "react";
+
+const VerifyRequestPage = ({ token }) => <VerifyRequestComponent token={token} />;
+
+VerifyRequestPage.getInitialProps = async (ctx) => {
+  authorizedPageSSR([Role.Any], ctx, true);
+  return { token: ctx.query.token };
+};
+
+VerifyRequestPage.config = {
+  header: false,
+  footer: false
+};
+
+export default VerifyRequestPage;

--- a/src/pages/group/[groupName]/continue/verify-invitation.tsx
+++ b/src/pages/group/[groupName]/continue/verify-invitation.tsx
@@ -1,0 +1,3 @@
+import VerifyInvitationPage from "../../../continue/verify-invitation";
+
+export default VerifyInvitationPage;

--- a/src/pages/group/[groupName]/continue/verify-request.tsx
+++ b/src/pages/group/[groupName]/continue/verify-request.tsx
@@ -1,0 +1,3 @@
+import VerifyRequestPage from "../../../continue/verify-request";
+
+export default VerifyRequestPage;

--- a/src/services/usergroup.service.ts
+++ b/src/services/usergroup.service.ts
@@ -44,7 +44,7 @@ export const axGetPages = async (userGroupId) => {
  */
 export const axVerifyInvitation = async (token) => {
   try {
-    await http.get(`${ENDPOINT.USERGROUP}/v1/group/validate/members/${token}`);
+    await http.post(`${ENDPOINT.USERGROUP}/v1/group/validate/members`, { token });
     return { success: true };
   } catch (e) {
     console.error(e);
@@ -60,7 +60,7 @@ export const axVerifyInvitation = async (token) => {
  */
 export const axVerifyRequest = async (token) => {
   try {
-    await http.get(`${ENDPOINT.USERGROUP}/v1/group/validate/request/${token}`);
+    await http.post(`${ENDPOINT.USERGROUP}/v1/group/validate/request`, { token });
     return { success: true };
   } catch (e) {
     console.error(e);

--- a/src/services/usergroup.service.ts
+++ b/src/services/usergroup.service.ts
@@ -44,7 +44,7 @@ export const axGetPages = async (userGroupId) => {
  */
 export const axVerifyInvitation = async (token) => {
   try {
-    await http.post(`${ENDPOINT.USERGROUP}/v1/accept-invitation`, { token });
+    await http.get(`${ENDPOINT.USERGROUP}/v1/group/validate/members/${token}`);
     return { success: true };
   } catch (e) {
     console.error(e);
@@ -60,7 +60,7 @@ export const axVerifyInvitation = async (token) => {
  */
 export const axVerifyRequest = async (token) => {
   try {
-    await http.post(`${ENDPOINT.USERGROUP}/v1/accept-invitation`, { token });
+    await http.get(`${ENDPOINT.USERGROUP}/v1/group/validate/request/${token}`);
     return { success: true };
   } catch (e) {
     console.error(e);

--- a/src/services/usergroup.service.ts
+++ b/src/services/usergroup.service.ts
@@ -35,3 +35,35 @@ export const axGetPages = async (userGroupId) => {
     return { success: false, data: [] };
   }
 };
+
+/**
+ * when user accepts invitation to be moderator of any userGroup
+ *
+ * @param {string} token
+ * @returns
+ */
+export const axVerifyInvitation = async (token) => {
+  try {
+    await http.post(`${ENDPOINT.USERGROUP}/v1/accept-invitation`, { token });
+    return { success: true };
+  } catch (e) {
+    console.error(e);
+    return { success: false };
+  }
+};
+
+/**
+ * userGroup moderators can accept request made by user to join userGroup
+ *
+ * @param {string} token
+ * @returns
+ */
+export const axVerifyRequest = async (token) => {
+  try {
+    await http.post(`${ENDPOINT.USERGROUP}/v1/accept-invitation`, { token });
+    return { success: true };
+  } catch (e) {
+    console.error(e);
+    return { success: false };
+  }
+};


### PR DESCRIPTION
This PR will add support for accepting invitations / requests for user group when accepted via email

### TODO
- [x] automatic login to continue (was already done)
- [x] verify request page w/ group context
- [x] verify invitation page w/ group context
- [x] Change dummy endpoint with back-end once done