### PR TITLE
fix: :recycle: register allow any region

### DIFF
--- a/src/components/pages/register/form/location.tsx
+++ b/src/components/pages/register/form/location.tsx
@@ -102,7 +102,6 @@ const LocationPicker = ({ form }) => {
               <Autocomplete
                 onLoad={setSearchBoxRef}
                 onPlaceChanged={handleOnSearchSelected}
-                options={GEOCODE_OPTIONS}
                 fields={AUTOCOMPLETE_FIELDS}
               >
                 <Input


### PR DESCRIPTION
Allows user to register without boundry restriction in location autocomplete