### PR TITLE
fix: :recycle: update params for user map

### DIFF
--- a/src/components/pages/user/show/user-info-tabs/observation/user-observations-map/index.tsx
+++ b/src/components/pages/user/show/user-info-tabs/observation/user-observations-map/index.tsx
@@ -14,7 +14,7 @@ export default function UserObservationsMap({ userId, groupId }) {
     <Box className="white-box">
       <BoxHeading>🗺️ {t("USER.OBSERVATIONS.MAP")}</BoxHeading>
       <ClusterMap
-        filter={{ authorId: userId, userGroupId, groupId }}
+        filter={{ user: userId, userGroupList: userGroupId, sGroup: groupId }}
         k={groupId}
         borderRadius={0}
       />


### PR DESCRIPTION
this will update query params to show `Observations Spread` from new endpoints