### PR TITLE
refactor: :recycle: observation/list stats tab no data correction

### DIFF
--- a/src/components/pages/observation/list/views/stats/species-groups.tsx
+++ b/src/components/pages/observation/list/views/stats/species-groups.tsx
@@ -26,13 +26,15 @@ const SpeciesGroups = ({ observationData, speciesGroup, filter }) => {
     }));
   }, [filter, observationData]);
 
-  return (
+  return filteredData.length > 0 ? (
     <Box className="white-box">
       <BoxHeading>📊 {t("LIST.CHART.SGROUP")}</BoxHeading>
       <Box p={4}>
         <VerticalBarChart h={365} data={filteredData} tooltipRenderer={SpeciesTooltipRenderer} />
       </Box>
     </Box>
+  ) : (
+    <></>
   );
 };
 

--- a/src/components/pages/observation/list/views/stats/species-groups.tsx
+++ b/src/components/pages/observation/list/views/stats/species-groups.tsx
@@ -34,7 +34,7 @@ const SpeciesGroups = ({ observationData, speciesGroup, filter }) => {
       </Box>
     </Box>
   ) : (
-    <></>
+    null
   );
 };
 

--- a/src/components/pages/observation/list/views/stats/states-distribution.tsx
+++ b/src/components/pages/observation/list/views/stats/states-distribution.tsx
@@ -25,7 +25,7 @@ const StatesDistribution = ({ observationData, filter }) => {
       .sort((a, b) => b.observations - a.observations);
   }, [filter, observationData]);
 
-  return (
+  return filteredStateData.length > 0 ? (
     <Box className="white-box">
       <BoxHeading>📊 {t("LIST.CHART.STATES")}</BoxHeading>
       <Box p={4}>
@@ -43,6 +43,8 @@ const StatesDistribution = ({ observationData, filter }) => {
         />
       </Box>
     </Box>
+  ) : (
+    <></>
   );
 };
 

--- a/src/components/pages/observation/list/views/stats/states-distribution.tsx
+++ b/src/components/pages/observation/list/views/stats/states-distribution.tsx
@@ -44,7 +44,7 @@ const StatesDistribution = ({ observationData, filter }) => {
       </Box>
     </Box>
   ) : (
-    <></>
+    null
   );
 };
 

--- a/src/components/pages/observation/list/views/stats/table-identifiers.tsx
+++ b/src/components/pages/observation/list/views/stats/table-identifiers.tsx
@@ -75,6 +75,6 @@ export default function IdentifiersTable({ data, title, loadMoreIdentifiers, fil
   ) : data.isLoading ? (
     <Skeleton h={450} borderRadius="md" />
   ) : (
-    <div>No Data</div>
+    <></>
   );
 }

--- a/src/components/pages/observation/list/views/stats/table-identifiers.tsx
+++ b/src/components/pages/observation/list/views/stats/table-identifiers.tsx
@@ -75,6 +75,6 @@ export default function IdentifiersTable({ data, title, loadMoreIdentifiers, fil
   ) : data.isLoading ? (
     <Skeleton h={450} borderRadius="md" />
   ) : (
-    <></>
+    null
   );
 }

--- a/src/components/pages/observation/list/views/stats/table-uploaders.tsx
+++ b/src/components/pages/observation/list/views/stats/table-uploaders.tsx
@@ -71,6 +71,6 @@ export default function UploadersTable({ data, title, loadMoreUploaders, filter 
   ) : data.isLoading ? (
     <Skeleton h={450} borderRadius="md" />
   ) : (
-    <></>
+    null
   );
 }

--- a/src/components/pages/observation/list/views/stats/table-uploaders.tsx
+++ b/src/components/pages/observation/list/views/stats/table-uploaders.tsx
@@ -71,6 +71,6 @@ export default function UploadersTable({ data, title, loadMoreUploaders, filter 
   ) : data.isLoading ? (
     <Skeleton h={450} borderRadius="md" />
   ) : (
-    <div>No Data</div>
+    <></>
   );
 }

--- a/src/components/pages/observation/list/views/stats/table.tsx
+++ b/src/components/pages/observation/list/views/stats/table.tsx
@@ -57,6 +57,6 @@ export default function LifeListTable({ data, title, loadMoreUniqueSpecies, filt
   ) : data.isLoading ? (
     <Skeleton h={450} borderRadius="md" />
   ) : (
-    <div>No Data</div>
+    <></>
   );
 }

--- a/src/components/pages/observation/list/views/stats/table.tsx
+++ b/src/components/pages/observation/list/views/stats/table.tsx
@@ -57,6 +57,6 @@ export default function LifeListTable({ data, title, loadMoreUniqueSpecies, filt
   ) : data.isLoading ? (
     <Skeleton h={450} borderRadius="md" />
   ) : (
-    <></>
+    null
   );
 }


### PR DESCRIPTION
observation/list page stats tab was throwing error when some of the data was unavailable and due to that error was being shown this PR gracefully handles missing data