### PR TITLE
fix: :bug: mobile input fields invisible on obs. create

### DIFF
--- a/src/components/@core/quill-input/index.tsx
+++ b/src/components/@core/quill-input/index.tsx
@@ -43,7 +43,7 @@ const QuillInput = ({ value: EValue, onChange }: QuillInputProps) => {
 
   useEffect(() => {
     if (quill) {
-      quill.clipboard.dangerouslyPasteHTML(value || "");
+      quill.setContents(quill.clipboard.convert(value || ""));
 
       quill.on("text-change", () => {
         setValue(quill.root.innerHTML);

--- a/src/components/pages/observation/create/form/index.tsx
+++ b/src/components/pages/observation/create/form/index.tsx
@@ -5,11 +5,7 @@ import { SubmitButton } from "@components/form/submit-button";
 import { yupResolver } from "@hookform/resolvers/yup";
 import useGlobalState from "@hooks/use-global-state";
 import CheckIcon from "@icons/check";
-import {
-  RESOURCES_UPLOADING,
-  SYNC_SINGLE_OBSERVATION,
-  TOGGLE_PHOTO_SELECTOR
-} from "@static/events";
+import { RESOURCES_UPLOADING, SYNC_SINGLE_OBSERVATION } from "@static/events";
 import { dateToUTC } from "@utils/date";
 import { cleanFacts, cleanTags } from "@utils/tags";
 import useTranslation from "next-translate/useTranslation";
@@ -37,7 +33,7 @@ export default function ObservationCreateForm({
 }) {
   const { t } = useTranslation();
   const { isOpen, onClose } = useDisclosure({ defaultIsOpen: true });
-  const [isSelectedImages, setIsSelectedImages] = useState(true);
+  const [isSelectedImages, setIsSelectedImages] = useState<boolean>();
   const [isSubmitDisabled, setIsSubmitDisabled] = useState();
   const [customFieldList] = useState(
     ObservationCreateFormData?.customField?.sort((a, b) => a.displayOrder - b.displayOrder)
@@ -79,13 +75,6 @@ export default function ObservationCreateForm({
       setIsSubmitDisabled(isUploading);
     },
     [RESOURCES_UPLOADING]
-  );
-
-  useListener(
-    (e) => {
-      setIsSelectedImages(e);
-    },
-    [TOGGLE_PHOTO_SELECTOR]
   );
 
   const hForm = useForm<any>({
@@ -250,7 +239,11 @@ export default function ObservationCreateForm({
       <PageHeading>👋 {t("observation:title")}</PageHeading>
       <FormProvider {...hForm}>
         <form onSubmit={hForm.handleSubmit(handleOnSubmit)}>
-          <Uploader name="resources" licensesList={licensesList} />
+          <Uploader
+            name="resources"
+            licensesList={licensesList}
+            onTabIndexChanged={(ti) => setIsSelectedImages(ti > 0)}
+          />
           <Box hidden={isSelectedImages}>
             <Recodata languages={languages} />
             <GroupSelector name="sGroup" label={t("form:species_groups")} options={speciesGroups} />

--- a/src/components/pages/observation/create/form/uploader/field.tsx
+++ b/src/components/pages/observation/create/form/uploader/field.tsx
@@ -24,7 +24,6 @@ export interface IDropzoneProps {
   isCreate?: boolean;
   children?;
   hidden?;
-  licensesList;
   onTabIndexChanged?;
 }
 

--- a/src/components/pages/observation/create/form/uploader/field.tsx
+++ b/src/components/pages/observation/create/form/uploader/field.tsx
@@ -8,10 +8,8 @@ import {
   Tabs
 } from "@chakra-ui/react";
 import useDidUpdateEffect from "@hooks/use-did-update-effect";
-import { TOGGLE_PHOTO_SELECTOR } from "@static/events";
 import useTranslation from "next-translate/useTranslation";
 import React, { useEffect, useState } from "react";
-import { emit } from "react-gbus";
 import { useController } from "react-hook-form";
 
 import AudioInput from "./audio-input";
@@ -27,9 +25,10 @@ export interface IDropzoneProps {
   children?;
   hidden?;
   licensesList;
+  onTabIndexChanged?;
 }
 
-const DropzoneField = ({ name, mb = 4, hidden }: IDropzoneProps) => {
+const DropzoneField = ({ name, mb = 4, hidden, onTabIndexChanged }: IDropzoneProps) => {
   const { observationAssets } = useObservationCreate();
   const [tabIndex, setTabIndex] = useState(0);
   const { t } = useTranslation();
@@ -40,13 +39,13 @@ const DropzoneField = ({ name, mb = 4, hidden }: IDropzoneProps) => {
     observationAssets?.length && field.onChange(observationAssets);
   }, []);
 
+  useEffect(() => {
+    onTabIndexChanged && onTabIndexChanged(tabIndex);
+  }, [tabIndex]);
+
   useDidUpdateEffect(() => {
     field.onChange(observationAssets);
   }, [observationAssets]);
-
-  useEffect(() => {
-    emit(TOGGLE_PHOTO_SELECTOR, tabIndex !== 0);
-  }, [tabIndex]);
 
   const onSelectionDone = () => setTabIndex(0);
 

--- a/src/components/pages/observation/create/form/uploader/index.tsx
+++ b/src/components/pages/observation/create/form/uploader/index.tsx
@@ -6,7 +6,11 @@ import IndexedDBProvider from "use-indexeddb";
 import DropzoneField, { IDropzoneProps } from "./field";
 import { ObservationCreateProvider } from "./use-observation-resources";
 
-const DropzoneFieldContainer = (props: IDropzoneProps) => {
+interface IDropzoneExtendedProps extends IDropzoneProps {
+  licensesList;
+}
+
+const DropzoneFieldContainer = (props: IDropzoneExtendedProps) => {
   const form = useFormContext();
 
   return (

--- a/src/static/events.ts
+++ b/src/static/events.ts
@@ -6,7 +6,6 @@ export const RESOURCES_UPLOADING = "resources_uploading";
 export const SYNC_SINGLE_OBSERVATION = "sync_single_observation";
 export const SYNC_SINGLE_OBSERVATION_DONE = "sync_single_observation_done";
 export const SYNC_SINGLE_OBSERVATION_ERROR = "sync_single_observation_error";
-export const TOGGLE_PHOTO_SELECTOR = "toggle_photo_uploader";
 
 export const SPECIES_FIELD_UPDATE = "sfe_start";
 export const SPECIES_FIELD_UPDATED = "sfe_done";


### PR DESCRIPTION
Fixes
- mobile input fields invisible when creating observations
  instead of using event-emitting I've used simple prop based callback to conditionally verify if tab is first or not
- `react-quill` auto focusing when page gets loaded in mobile