### PR TITLE
refactor: :recycle: style cleanup + shouldPortal

### DIFF
--- a/src/components/form/configs.tsx
+++ b/src/components/form/configs.tsx
@@ -16,7 +16,6 @@ export const selectStyles = {
   }),
   valueContainer: (p) => ({ ...p, height: "38px" }),
   menu: (p) => ({ ...p, minWidth: "20em" }),
-  menuList:(p)=>({...p,maxHeight:"9em"}),
   menuPortal: (p) => ({ ...p, zIndex: 1900 }),
   clearIndicator: (base, state) => ({
     ...base,

--- a/src/components/form/select.tsx
+++ b/src/components/form/select.tsx
@@ -8,7 +8,7 @@ import { ClearIndicator, selectStyles } from "./configs";
 
 interface SelectInputFieldProps {
   name: string;
-  label: string;
+  label?: string;
   mb?: number;
   disabled?: boolean;
   hint?: string;
@@ -19,6 +19,7 @@ interface SelectInputFieldProps {
   isControlled?: boolean;
   onChangeCallback?;
   shouldPortal?;
+  placeholder?;
   hidden?;
 }
 const DefaultOptionComponent = (p: any) => <components.Option {...p} />;
@@ -37,6 +38,7 @@ export const SelectInputField = ({
   shouldPortal,
   onChangeCallback,
   hidden,
+  placeholder,
   ...props
 }: SelectInputFieldProps) => {
   const { field, fieldState } = useController({ name });
@@ -51,7 +53,7 @@ export const SelectInputField = ({
       isRequired={isRequired}
       {...props}
     >
-      <FormLabel htmlFor={name}>{label}</FormLabel>
+      {label && <FormLabel htmlFor={name}>{label}</FormLabel>}
       <Select
         id={name}
         inputId={name}
@@ -65,6 +67,7 @@ export const SelectInputField = ({
           Option: optionComponent,
           ClearIndicator
         }}
+        placeholder={placeholder}
         menuPortalTarget={shouldPortal ? MENU_PORTAL_TARGET : undefined}
         isSearchable={true}
         isDisabled={disabled}

--- a/src/components/pages/datatable/create/form/uploader/file-uploader-field/options-field.tsx
+++ b/src/components/pages/datatable/create/form/uploader/file-uploader-field/options-field.tsx
@@ -110,6 +110,7 @@ export default function Fields({
                   {fields.map((field, index) => (
                     <Td key={field.id}>
                       <SelectInputField
+                        shouldPortal={true}
                         name={`columnsMapping.${index}.fieldKey`}
                         label={t("common:actions.flag.category")}
                         options={formatOptions(


### PR DESCRIPTION
Current dropdowns are showing as `9em` max-height, this removes that override style and moves datatable component where issue was happening to portal