### PR TITLE
using plantnet post request for identification

### DIFF
--- a/src/components/form/select-async.tsx
+++ b/src/components/form/select-async.tsx
@@ -1,9 +1,10 @@
+import { ChevronDownIcon } from "@chakra-ui/icons";
 import { FormControl, FormErrorMessage, FormHelperText, FormLabel } from "@chakra-ui/react";
 import { MENU_PORTAL_TARGET } from "@static/constants";
 import debounce from "debounce-promise";
 import React, { useEffect, useMemo, useState } from "react";
 import { useController, useFormContext } from "react-hook-form";
-import { components } from "react-select";
+import { components, DropdownIndicatorProps } from "react-select";
 import AsyncSelect from "react-select/async";
 import AsyncSelectCreatable from "react-select/async-creatable";
 
@@ -30,6 +31,7 @@ interface ISelectProps {
   isClearable?;
   resetOnSubmit?;
   isRaw?;
+  openMenuOnFocus?: boolean;
 }
 
 const dummyOnQuery = (q) =>
@@ -40,6 +42,14 @@ const dummyOnQuery = (q) =>
   });
 
 const DefaultOptionComponent = (p: any) => <components.Option {...p} />;
+
+const DropdownIndicator = (props: DropdownIndicatorProps) => {
+  return (
+    <components.DropdownIndicator {...props}>
+      <ChevronDownIcon />
+    </components.DropdownIndicator>
+  );
+};
 
 export const SelectAsyncInputField = ({
   name,
@@ -61,6 +71,7 @@ export const SelectAsyncInputField = ({
   resetOnSubmit = true,
   isClearable = true,
   isRaw,
+  openMenuOnFocus = false,
   ...props
 }: ISelectProps) => {
   const form = useFormContext();
@@ -112,7 +123,7 @@ export const SelectAsyncInputField = ({
         components={{
           Option: optionComponent,
           ClearIndicator,
-          DropdownIndicator: () => null,
+          DropdownIndicator,
           IndicatorSeparator: () => null
         }}
         value={selected}
@@ -123,6 +134,7 @@ export const SelectAsyncInputField = ({
         placeholder={placeholder || label}
         noOptionsMessage={() => null}
         ref={selectRef}
+        openMenuOnFocus={openMenuOnFocus}
         {...reactSelectProps}
       />
       <FormErrorMessage children={fieldState?.error?.message} />

--- a/src/components/pages/observation/create/form/recodata/scientific-name.tsx
+++ b/src/components/pages/observation/create/form/recodata/scientific-name.tsx
@@ -1,4 +1,4 @@
-import { Badge, Box, Image, SimpleGrid, Spacer, Stack, Tag, Text } from "@chakra-ui/react";
+import { Badge, Box, Image, Link, Spacer, Stack, Tag, Text } from "@chakra-ui/react";
 import { ExtendedTaxonDefinition } from "@interfaces/esmodule";
 import { axSearchSpeciesByText } from "@services/esmodule.service";
 import { TAXON_BADGE_COLORS } from "@static/constants";
@@ -7,15 +7,17 @@ import useTranslation from "next-translate/useTranslation";
 import React from "react";
 import { components } from "react-select";
 
-export const Thumbnails = ({ images }) => {
-  return (
-    <SimpleGrid columns={[3, 3, 3, 3]} spacing="2" alignItems="center" justifyContent="right">
-      {images.map((img) => (
-        <Image src={img.url.s} boxSize="3em" />
-      ))}
-    </SimpleGrid>
-  );
-};
+// export const Thumbnails = ({ images }) => {
+//   return (
+//     <SimpleGrid columns={[5, 5, 5, 5]} spacing="2" alignItems="center" justifyContent="right">
+//       {images.map((img) => (
+//         <Link href={img.url.o} isExternal={true} target="_blank">
+//           <Image src={img.url.s} boxSize="4em" onClick={(e) => e.stopPropagation()} />
+//         </Link>
+//       ))}
+//     </SimpleGrid>
+//   );
+// };
 
 export const ScientificNameOption = ({ children, ...props }: any) => {
   const hiddenIcon = !props.data["__isNew__"];
@@ -23,7 +25,7 @@ export const ScientificNameOption = ({ children, ...props }: any) => {
 
   return (
     <components.Option {...props}>
-      <Stack isInline={true} alignItems="center" overflow="hidden" justifyContent="space-between">
+      <Stack isInline={true} alignItems="center">
         {hiddenIcon && (
           <Image
             boxSize="2rem"
@@ -31,17 +33,17 @@ export const ScientificNameOption = ({ children, ...props }: any) => {
             fallbackSrc={props.data.group}
           />
         )}
-        <Box>
-          {props.data.score && (
+
+        {props.data.score && (
+          <Box>
             <Tag variant="solid" colorScheme="green" whiteSpace="nowrap">
               {props.data.score}
             </Tag>
-          )}
-        </Box>
+          </Box>
+        )}
 
         <Box>
           {children}
-
           {props.data.acceptedNames && <Text color="gray.600">{props.data.acceptedNames}</Text>}
           <Stack isInline={true} mt={1} spacing={2}>
             {props.data.rank && <Badge>{props.data.rank}</Badge>}
@@ -60,6 +62,13 @@ export const ScientificNameOption = ({ children, ...props }: any) => {
         </Box>
 
         <Spacer />
+
+        {props.data.images &&
+          props.data.images.slice(0, 1).map((img) => (
+            <Link href={img.url.o} isExternal={true} target="_blank">
+              <Image src={img.url.s} boxSize="4em" onClick={(e) => e.stopPropagation()} />
+            </Link>
+          ))}
       </Stack>
     </components.Option>
   );

--- a/src/components/pages/observation/create/form/recodata/scientific-name.tsx
+++ b/src/components/pages/observation/create/form/recodata/scientific-name.tsx
@@ -7,18 +7,6 @@ import useTranslation from "next-translate/useTranslation";
 import React from "react";
 import { components } from "react-select";
 
-// export const Thumbnails = ({ images }) => {
-//   return (
-//     <SimpleGrid columns={[5, 5, 5, 5]} spacing="2" alignItems="center" justifyContent="right">
-//       {images.map((img) => (
-//         <Link href={img.url.o} isExternal={true} target="_blank">
-//           <Image src={img.url.s} boxSize="4em" onClick={(e) => e.stopPropagation()} />
-//         </Link>
-//       ))}
-//     </SimpleGrid>
-//   );
-// };
-
 export const ScientificNameOption = ({ children, ...props }: any) => {
   const hiddenIcon = !props.data["__isNew__"];
   const { t } = useTranslation();

--- a/src/components/pages/observation/show/suggestion/add-suggestion.tsx
+++ b/src/components/pages/observation/show/suggestion/add-suggestion.tsx
@@ -213,17 +213,19 @@ export default function AddSuggestion({
                       shouldPortal={true}
                     />
                   </SimpleGrid>
-
-                  <SelectAsyncInputField
-                    name="scientificNameTaxonId"
-                    label={t("observation:scientific_name")}
-                    onQuery={onScientificNameQuery}
-                    optionComponent={ScientificNameOption}
-                    placeholder={t("form:min_three_chars")}
-                    onChange={onScientificNameChange}
-                    options={predictions || []}
-                    selectRef={scientificRef}
-                  />
+                  <Box onMouseEnter={() => scientificRef.current.focus()}>
+                    <SelectAsyncInputField
+                      name="scientificNameTaxonId"
+                      label={t("observation:scientific_name")}
+                      onQuery={onScientificNameQuery}
+                      optionComponent={ScientificNameOption}
+                      placeholder={t("form:min_three_chars")}
+                      onChange={onScientificNameChange}
+                      options={predictions || []}
+                      selectRef={scientificRef}
+                      openMenuOnFocus={true}
+                    />
+                  </Box>
 
                   {predictions.length > 0 && (
                     <Text color="green">{t("observation:plantnet.pedictions_ready")}</Text>
@@ -236,6 +238,7 @@ export default function AddSuggestion({
                         setX={setPredictions}
                         isOpenImageModal={isOpenImageModal}
                         onCloseImageModal={onCloseImageModal}
+                        selectRef={scientificRef}
                       />
                     )}
 

--- a/src/components/pages/observation/show/suggestion/plantnet-prediction.tsx
+++ b/src/components/pages/observation/show/suggestion/plantnet-prediction.tsx
@@ -19,7 +19,7 @@ import useTranslation from "next-translate/useTranslation";
 import React, { useEffect, useState } from "react";
 
 import ImagePicker from "./image-picker";
-const PlantnetPrediction = ({ images, setX, isOpenImageModal, onCloseImageModal }) => {
+const PlantnetPrediction = ({ images, setX, isOpenImageModal, onCloseImageModal, selectRef }) => {
   const toast = useToast();
   const toastIdRef = React.useRef<any>();
   const { t } = useTranslation();
@@ -95,6 +95,10 @@ const PlantnetPrediction = ({ images, setX, isOpenImageModal, onCloseImageModal 
       });
       onCloseImageModal();
       setTimeout(() => toast.close(toastIdRef.current), 1000);
+
+      if (selectRef) {
+        selectRef.current.focus();
+      }
     } else {
       toast.update(toastIdRef.current, {
         title: `${t("observation:plantnet.failed_to_generate_predictions")}`,


### PR DESCRIPTION
1)Getting plantnet predictions data from their post request endpoint instead of get request endpoint. This requires us to convert resized images into blobs and send them as formdata
2)Included the feature to automatically open suggestions/predictions from plantnet as soon as the predictions are ready/generated.
3)Included the feature to display thumbnail image of each plantnet prediction with a link to the original image by plantnet.