### PR TITLE
fix: :bug: Species groups panel unaivalable

### DIFF
--- a/src/components/pages/document/common/use-document-filter.tsx
+++ b/src/components/pages/document/common/use-document-filter.tsx
@@ -3,8 +3,9 @@ import useGlobalState from "@hooks/use-global-state";
 import { DocumentData } from "@interfaces/custom";
 import { UserGroupIbp } from "@interfaces/document";
 import { axGroupList } from "@services/app.service";
-import { axGetDocumentSpeciesGroups, axGetListData } from "@services/document.service";
+import { axGetListData } from "@services/document.service";
 import { axGetLandscapeList } from "@services/landscape.service";
+import { axGetSpeciesGroupList } from "@services/taxonomy.service";
 import { axGetAllHabitat } from "@services/utility.service";
 import { isBrowser } from "@static/constants";
 import { DEFAULT_FILTER, LIST_PAGINATION_LIMIT } from "@static/documnet-list";
@@ -56,7 +57,7 @@ export const DocumentFilterProvider = (props) => {
       window.history.pushState("", "", `?${stringify({ ...filter.f, offset: initialOffset })}`);
     }
 
-    axGetDocumentSpeciesGroups().then(({ data: species }) => {
+    axGetSpeciesGroupList().then(({ data: species }) => {
       setSpecies(species);
     });
     axGetAllHabitat().then(({ data: habitat }) => {

--- a/src/pages/document/create.tsx
+++ b/src/pages/document/create.tsx
@@ -1,8 +1,9 @@
 import { authorizedPageSSR } from "@components/auth/auth-redirect";
 import DocumentCreatePageComponent from "@components/pages/document/create";
 import { Role } from "@interfaces/custom";
-import { axGetDocumentSpeciesGroups, axGetDocumentTypes } from "@services/document.service";
+import { axGetDocumentTypes } from "@services/document.service";
 import { axGetLicenseList } from "@services/resources.service";
+import { axGetSpeciesGroupList } from "@services/taxonomy.service";
 import { axGetAllHabitat } from "@services/utility.service";
 import React from "react";
 
@@ -18,7 +19,7 @@ const DocumentCreatePage = ({ speciesGroups, habitats, documentTypes, licensesLi
 DocumentCreatePage.getInitialProps = async (ctx) => {
   authorizedPageSSR([Role.Any], ctx);
 
-  const { data: speciesGroups } = await axGetDocumentSpeciesGroups();
+  const { data: speciesGroups } = await axGetSpeciesGroupList();
   const { data: habitatList } = await axGetAllHabitat();
   const { data: licensesList } = await axGetLicenseList();
   const { data: documentTypes } = await axGetDocumentTypes();

--- a/src/pages/document/show/[documentId].tsx
+++ b/src/pages/document/show/[documentId].tsx
@@ -1,5 +1,6 @@
 import DocumentShowComponent from "@components/pages/document/show";
-import { axGetDocumentById, axGetDocumentSpeciesGroups } from "@services/document.service";
+import { axGetDocumentById } from "@services/document.service";
+import { axGetSpeciesGroupList } from "@services/taxonomy.service";
 import { axGetAllHabitat } from "@services/utility.service";
 import { getDocumentURL, isLinkPDF } from "@utils/document";
 import React from "react";
@@ -9,7 +10,7 @@ const DocumentShowPage = (props) => <DocumentShowComponent {...props} />;
 export const getServerSideProps = async (ctx) => {
   const [document, speciesGroups, habitatList] = await Promise.all([
     axGetDocumentById(ctx.query.documentId),
-    axGetDocumentSpeciesGroups(),
+    axGetSpeciesGroupList(),
     axGetAllHabitat()
   ]);
 

--- a/src/services/document.service.ts
+++ b/src/services/document.service.ts
@@ -141,16 +141,6 @@ export const axGetDocumentPermissions = async (documentId) => {
   }
 };
 
-export const axGetDocumentSpeciesGroups = async () => {
-  try {
-    const { data } = await plainHttp.get(`${ENDPOINT.DOCUMENT}/v1/services/speciesGroup/all`);
-    return { success: true, data };
-  } catch (e) {
-    console.error(e);
-    return { success: false, data: [] };
-  }
-};
-
 export const axGetDocumentTypes = async () => {
   try {
     const { data } = await plainHttp.get(`${ENDPOINT.DOCUMENT}/v1/services/bib/item/all`);


### PR DESCRIPTION
## Species group panel was missing from 3 places
1. Document create page
2. Document show page (right panel)
3. Species group filter on document list page
## Cause
In order to decouple document module from taxonomy , an endpoint for fetching species group from document microservice (which is basically calling an endpoint in taxonomy) was deleted, but corresponding changes were not made on UI codebase.

## Fix
For IBP like portals,directly call the `/species/all` endpoint.