### PR TITLE
Reaf: Modify getIcon function to accept a 'purpose' parameter

### DIFF
--- a/src/pages/api/manifest.json.ts
+++ b/src/pages/api/manifest.json.ts
@@ -6,7 +6,7 @@ const getIcon = (p) => ({
   src: compiledMessage(RESOURCE_SIZE.MANIFEST, p).replace("/crop/", "/logo/"),
   sizes: `${p.size}x${p.size}`,
   type: "image/png",
-  purpose: "any maskable"
+  purpose: p.purpose
 });
 
 export default (req, res) => {
@@ -24,6 +24,9 @@ export default (req, res) => {
     theme_color: "#363636",
     display: "standalone",
     start_url: "/",
-    icons: [getIcon({ icon, size: 192 }), getIcon({ icon, size: 512 })]
+    icons: [
+      getIcon({ icon, size: 192, purpose: "any" }),
+      getIcon({ icon, size: 512, purpose: "maskable" })
+    ]
   });
 };

--- a/src/pages/api/manifest.json.ts
+++ b/src/pages/api/manifest.json.ts
@@ -26,6 +26,7 @@ export default (req, res) => {
     start_url: "/",
     icons: [
       getIcon({ icon, size: 192, purpose: "any" }),
+      getIcon({ icon, size: 192, purpose: "maskable" }),
       getIcon({ icon, size: 512, purpose: "maskable" })
     ]
   });


### PR DESCRIPTION
Refactored code to pass purpose parameters dynamically.

More info on purpose parameters: https://web.dev/maskable-icon/#how-do-i-adopt-maskable-icons