### PR TITLE
fix: :bug: wrong query param sent to backend

### DIFF
--- a/src/components/pages/datatable/common/use-datatable-filter.tsx
+++ b/src/components/pages/datatable/common/use-datatable-filter.tsx
@@ -22,7 +22,7 @@ export interface DataTableData {
 export interface showPageFilters {
   offset?: string;
   limit?: string;
-  sortOn?: string;
+  sort?: string;
   userGroupId?: string;
 }
 

--- a/src/components/pages/datatable/list/header/index.tsx
+++ b/src/components/pages/datatable/list/header/index.tsx
@@ -15,7 +15,7 @@ export default function Header() {
     const v = e?.target?.value;
     setFilter((_draft) => {
       _draft.f.offset = 0;
-      _draft.f.sortOn = `${v}`;
+      _draft.f.sort = `${v}`;
     });
   };
 
@@ -39,7 +39,7 @@ export default function Header() {
               <Select
                 maxW="10rem"
                 aria-label={t("common:list.sort_by")}
-                value={filter?.sortOn}
+                value={filter?.sort}
                 onChange={handleOnSort}
               >
                 {sortByOptions.map(({ name, key }) => (


### PR DESCRIPTION
This PR solves the issue of sending wrong query params to the backend, from the datatable list page, for last updated/last created filter