### PR TITLE
refactor: :recycle: changed base path domain for pdf

### DIFF
--- a/src/utils/media.ts
+++ b/src/utils/media.ts
@@ -1,3 +1,4 @@
+import SITE_CONFIG from "@configs/site-config";
 import { ENDPOINT } from "@static/constants";
 import { OBSERVATION_FALLBACK } from "@static/inline-images";
 import { ASSET_TYPES } from "@static/observation-create";
@@ -129,5 +130,5 @@ export const getDocumentPath = (resourceUrl): string => {
 export const getDocumentFilePath = (resourceUrl): string => {
   return resourceUrl.startsWith("http")
     ? resourceUrl
-    : `${ENDPOINT.RAW}/content/documents${resourceUrl}`;
+    : `${SITE_CONFIG.DOCUMENT.BASE_PATH}/content/documents${resourceUrl}`;
 };


### PR DESCRIPTION
This PR resolves the issue of pdf-viewer not being able to display the pdf on the browser (ON IBP). It was caused by some config changes  in our internal network of ibp due to which pdf files were not coming up when referenced through the ibp main domain.